### PR TITLE
Stabilize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 0.2
 - Added `ebsp_message`
-- Shared memory in one large block (wrapper read/write functions with offset)
+- External memory in one large block
 - Fixed hardcoded BSP addresses to no longer overlap
+- All BSP variables are stored in a struct
 - Host checks for `MAX_N_REGISTER` and outputs warning if reached.
 - Added memory inspector with `ebsp_inspector_enable()`.
 

--- a/examples/bspbench/e_bspbench.c
+++ b/examples/bspbench/e_bspbench.c
@@ -41,6 +41,8 @@ float *vecallocd(int n) {
         if(address >= 0x6000) /* FIXME HARDCODE WARNING */
             return NULL; /* OUT OF MEMORY (in 0x4000 - 0x6000) */
     } 
+
+    ebsp_message("vecallocd(%d) -> %p. Alloc used [0x4000, %p[ Stack used [%p, 0x8000[", n, pd, address, e_reg_read(E_REG_R13));
     
     return pd; 
 } /* end vecallocd */ 
@@ -156,9 +158,9 @@ int main() { /*  bsp_bench */
                 for(s1=0; s1<p; s1++)
                     r += nflops/Time[s1];
                 r /= (float) p; 
-                /*printf("n = %5d min = %7.3lf max = %7.3lf av = %7.3lf Mflop/s ",
+                ebsp_message("n = %5d min = %7.3lf max = %7.3lf av = %7.3lf Mflop/s ",
                        n, nflops/(maxtime*MEGA),nflops/(mintime*MEGA), r/MEGA);
-                fflush(stdout); */
+                /* fflush(stdout); */
                 /*  Output for fooling benchmark-detecting compilers */
                 /* printf(" fool=%7.1lf\n",y[n-1]+z[n-1]); */
             } 
@@ -195,17 +197,17 @@ int main() { /*  bsp_bench */
         /* Compute time of one h-relation */
         if (s == 0) {
             t[h] = (time*r)/(float)NITERS;
-            /*printf("Time of %5d-relation = %lf sec = %8.0lf flops\n",
-                   h, time/NITERS, t[h]); fflush(stdout);*/
+            ebsp_message("Time of %5d-relation = %lf sec = %8.0lf flops\n",
+                   h, time/NITERS, t[h]); //fflush(stdout);
         }
     }
 
     if (s == 0) {
-        /* printf("size of float = %d bytes\n",(int)SZDBL); */
+        ebsp_message("size of float = %d bytes\n",(int)SZDBL);
         leastsquares(0, p, t, &g0, &l0); 
-        /* printf("Range h=0 to p   : g = %.1lf, l = %.1lf\n",g0,l0); */
+        ebsp_message("Range h=0 to p   : g = %.1lf, l = %.1lf\n",g0,l0);
         leastsquares(p, MAXH, t, &g, &l);
-        /* printf("Range h=p to HMAX: g = %.1lf, l = %.1lf\n",g,l); */
+        ebsp_message("Range h=p to HMAX: g = %.1lf, l = %.1lf\n",g,l);
 
         /* Write essential results! */
         int* pOut = (void*)0x6000;

--- a/examples/bspbench/e_bspbench.c
+++ b/examples/bspbench/e_bspbench.c
@@ -42,7 +42,7 @@ float *vecallocd(int n) {
             return NULL; /* OUT OF MEMORY (in 0x4000 - 0x6000) */
     } 
 
-    ebsp_message("vecallocd(%d) -> %p. Alloc used [0x4000, %p[ Stack used [%p, 0x8000[", n, pd, address, e_reg_read(E_REG_R13));
+    ebsp_message("vecallocd(%d) -> %p. Alloc used [0x4000, %p[ Stack used [%p, 0x8000[", n, pd, address, &pd);
     
     return pd; 
 } /* end vecallocd */ 

--- a/examples/bspbench/host_bspbench.c
+++ b/examples/bspbench/host_bspbench.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv){
         fprintf(stderr, "[BSPBENCH] bsp_begin() failed\n");
     }
     printf("Using %i processors!\n", bsp_nprocs()); fflush(stdout);
-    spmd_epiphany(); 
+    ebsp_spmd();
 
     //Get p, r, g and l
     int p;

--- a/include/common.h
+++ b/include/common.h
@@ -30,76 +30,68 @@ see the files COPYING and COPYING.LESSER. If not, see
 
 #define MAX_NAME_SIZE 30
 
-//Every core has MAX_N_REGISTER
-//Every register is sizeof(void*) = 4
-//So NCORES*MAX_N_REGISTER*4 is required
-//for registermap buffer
+// Every variable that is registered with bsp_push_reg
+// gives 16 addresses (the locations on the different cores).
+// An address takes 4 bytes, and MAX_N_REGISTER is the maximum
+// amount of variables that can be registered so in total we need
+// NCORES * MAX_N_REGISTER * 4 bytes
+// to save all this data
 #define MAX_N_REGISTER          40
 
-//struct for local eCore bsp variables
-//every core has a copy at local core memory
-//these used to be hardcoded at 0x6000
-//but are now stored as a global variable in the binary
+// ebsp_core_data holds local bsp variables for the epiphany cores
+// Every core has a copy in its local space
 typedef struct {
-    int                     _pid;
+    int                     pid;
     int                     nprocs;
     volatile int            syncstate; //ARM core will set this, epiphany will poll this
     volatile int            msgflag;
     float                   remotetimer;
-    unsigned int            _initial_time;
+    unsigned int            initial_time;
     void*                   registermap[MAX_N_REGISTER*_NPROCS];
     //volatile e_barrier_t    syncbarrier[_NPROCS]; //16 bytes
     //e_barrier_t*            syncbarrier_tgt[_NPROCS]; //16 pointers to the bytes on other cores
-} ebsp_coredata;
+} ebsp_core_data;
 
-//Buffer for ebsp_message
 typedef struct {
     char msg[128];
 } ebsp_message_buf;
 
-//struct for eCore --> ARM communication
-//This is located at "external memory"
-//meaning on the epiphany side, but not
-//in a local core's memory
-//The epiphany cores write a value here once
-//and the arm core polls these values
+// ebsp_comm_buf is a struct for epiphany -> ARM communication
+// It is located in "external memory", meaning on the epiphany device
+// but not in one of the cores internal memory
+// The epiphany cores write a value here once
+// and the arm core polls these values
 //
-//Note that we do NOT want:
-// struct{
-//     int syncstate;
-//     int msgflag;
-//     ...;
-//  } coreinfo;
-//  struct{
-//     coreinfo cores[16];
-//  } ebsp_comm_buf;
+// Note that we do NOT want:
+//      struct{
+//         int syncstate;
+//         int msgflag;
+//         ...;
+//      } coreinfo;
 //
-//  This is not efficient because by interlacing
-//  the data for different cores (all syncstate flags are
-//  in one memory chunk, all msgflags in the next) we can read
-//  all syncstate flags in ONE e_read call instead of 16
+//      struct{
+//         coreinfo cores[16];
+//      } ebsp_comm_buf;
+//
+// This is not efficient because by interlacing
+// the data for different cores (all syncstate flags are
+// in one memory chunk, all msgflags in the next) we can read
+// all syncstate flags in ONE e_read call instead of 16
 typedef struct {
-    int                 syncstate[_NPROCS]; //epiphany cores will set these, ARM core will poll these
+    int                 syncstate[_NPROCS];
     void*               pushregloc[_NPROCS];
     int                 msgflag[_NPROCS];
     ebsp_message_buf    message[_NPROCS];
-    ebsp_coredata*      coredata[_NPROCS];
-    int                 nprocs;
+    ebsp_core_data*     coredata[_NPROCS];
 } ebsp_comm_buf;
 
-//ARM will e_alloc COMMBUF_OFFSET
+// ARM will e_alloc COMMBUF_OFFSET
+// This same block will appear at COMMBUF_EADDR on epiphany
 #define COMMBUF_OFFSET 0x01000000
-//This same block will appear at COMMBUF_EADDR
-//on epiphany
 #define COMMBUF_EADDR  0x8f000000
 
-#define CORE_ID _pid
-#define CORE_ROW e_group_config.core_row
-#define CORE_COL e_group_config.core_col
-
-//Do not start at 0 so that we can
-//check if the variable has been
-//initialized at all
+// Possible values for syncstate
+// They start at 1 so that 0 means that the variable was not initialized
 #define STATE_RUN       1
 #define STATE_SYNC      2
 #define STATE_CONTINUE  3
@@ -109,6 +101,6 @@ typedef struct {
 #define NCORES (e_group_config.group_rows*e_group_config.group_cols)
 #define MAX_NCORES 64
 
-//clockspeed of Epiphany in cycles/second
+// Clockspeed of Epiphany in cycles/second
 #define CLOCKSPEED 800000000.
 #define ARM_CLOCKSPEED 20000.

--- a/include/common.h
+++ b/include/common.h
@@ -24,7 +24,7 @@ see the files COPYING and COPYING.LESSER. If not, see
 
 #pragma once
 
-#define DEBUG
+//#define DEBUG
 
 #define _NPROCS 16
 

--- a/include/common.h
+++ b/include/common.h
@@ -48,8 +48,6 @@ typedef struct {
     float                   remotetimer;
     unsigned int            initial_time;
     void*                   registermap[MAX_N_REGISTER*_NPROCS];
-    //volatile e_barrier_t    syncbarrier[_NPROCS]; //16 bytes
-    //e_barrier_t*            syncbarrier_tgt[_NPROCS]; //16 pointers to the bytes on other cores
 } ebsp_core_data;
 
 typedef struct {

--- a/include/common.h
+++ b/include/common.h
@@ -24,7 +24,9 @@ see the files COPYING and COPYING.LESSER. If not, see
 
 #pragma once
 
-//#define DEBUG
+#define DEBUG
+
+#define _NPROCS 16
 
 #define MAX_NAME_SIZE 30
 
@@ -38,7 +40,7 @@ see the files COPYING and COPYING.LESSER. If not, see
 //every core has a copy at local core memory
 //these used to be hardcoded at 0x6000
 //but are now stored as a global variable in the binary
-struct {
+typedef struct {
     int                     _pid;
     int                     nprocs;
     volatile int            syncstate; //ARM core will set this, epiphany will poll this
@@ -51,7 +53,7 @@ struct {
 } ebsp_coredata;
 
 //Buffer for ebsp_message
-struct {
+typedef struct {
     char msg[128];
 } ebsp_message_buf;
 
@@ -76,7 +78,7 @@ struct {
 //  the data for different cores (all syncstate flags are
 //  in one memory chunk, all msgflags in the next) we can read
 //  all syncstate flags in ONE e_read call instead of 16
-struct {
+typedef struct {
     int                 syncstate[_NPROCS]; //epiphany cores will set these, ARM core will poll these
     void*               pushregloc[_NPROCS];
     int                 msgflag[_NPROCS];
@@ -107,7 +109,6 @@ struct {
 #define NCORES (e_group_config.group_rows*e_group_config.group_cols)
 #define MAX_NCORES 64
 
-#define _NPROCS 16
 //clockspeed of Epiphany in cycles/second
 #define CLOCKSPEED 800000000.
 #define ARM_CLOCKSPEED 20000.

--- a/include/host_bsp.h
+++ b/include/host_bsp.h
@@ -43,10 +43,11 @@ typedef struct _bsp_state_t
     // Number of processors in use
     int nprocs_used;
 
-    //Shared memory segment
-    //Every core has SHM_SIZE_PER_CORE of space in this
-    //Within each space, SHM_OFFSET_xxx specify meaning
-    e_mem_t sharedmemseg;
+    // External memory that holsd ebsp_comm_buf
+    e_mem_t emem;
+    // Local copy of ebsp_comm_buf to copy from and
+    // copy into.
+    ebsp_comm_buf comm_buf;
 
     int num_vars_registered;
 

--- a/src/e_bsp.c
+++ b/src/e_bsp.c
@@ -168,7 +168,10 @@ void bsp_hpput(int pid, const void *src, void *dst, int offset, int nbytes)
     for(slotID=0; ; slotID++) {
 #ifdef DEBUG
         if(slotID >= MAX_N_REGISTER)
+        {
+            ebsp_message("ERROR: bsp_hpput(%d, %p, %p, %d, %d) could not find dst", pid, src, dst, offset, nbytes);
             return;
+        }
 #endif
         if(registermap[_nprocs*slotID+pid] == dst)
             break;

--- a/src/e_bsp.c
+++ b/src/e_bsp.c
@@ -25,10 +25,10 @@ see the files COPYING and COPYING.LESSER. If not, see
 #include "e_bsp.h"
 #include <e-lib.h>
 #include <stdio.h>
-#include <stdarg.h> //for va_list
+#include <stdarg.h>
 #include <string.h>
 
-//All bsp variables for this core
+// All bsp variables for this core
 ebsp_core_data coredata;
 ebsp_comm_buf* comm_buf = (ebsp_comm_buf*)COMMBUF_EADDR;
 
@@ -42,9 +42,9 @@ void bsp_begin()
     int cols = e_group_config.group_cols;
 
     // Initialize local data
-    coredata.pid = col + cols*row;
+    coredata.pid = col + cols * row;
     coredata.msgflag = 0;
-    for(i = 0; i < MAX_N_REGISTER*coredata.nprocs; i++)
+    for(i = 0; i < MAX_N_REGISTER * coredata.nprocs; i++)
         coredata.registermap[i] = 0;
 
     // Send &coredata to ARM so that ARM can fill it with values
@@ -58,7 +58,7 @@ void bsp_begin()
     // Now the ARM has entered nprocs and remotetimer
 
     // Initialize epiphany timer
-    e_ctimer_start(E_CTIMER_0, E_CTIMER_CLK);//TODO: E_CTIMER_CLK IS ONLY 255?
+    e_ctimer_start(E_CTIMER_0, E_CTIMER_CLK);
     coredata.initial_time = e_ctimer_get(E_CTIMER_0);
 }
 
@@ -66,7 +66,7 @@ void bsp_end()
 {
     bsp_sync();
     _write_syncstate(STATE_FINISH);
-    //TODO: halt execution
+    // TODO: halt execution
 }
 
 int bsp_nprocs()
@@ -87,7 +87,7 @@ float bsp_time()
     if(_current_time == 0)
         return -1.0;
 #endif
-    return (coredata.initial_time - _current_time)/CLOCKSPEED;
+    return (coredata.initial_time - _current_time) / CLOCKSPEED;
 }
 
 float bsp_remote_time()
@@ -105,8 +105,8 @@ void bsp_sync()
 
 void _write_syncstate(int state)
 {
-    coredata.syncstate = state; //local variable
-    comm_buf->syncstate[coredata.pid] = state; //being polled by ARM
+    coredata.syncstate = state; // local variable
+    comm_buf->syncstate[coredata.pid] = state; // being polled by ARM
 }
 
 // Memory
@@ -129,19 +129,19 @@ void bsp_hpput(int pid, const void *src, void *dst, int offset, int nbytes)
 {
     int slotID;
     void* adj_dst;
-    for(slotID=0; ; slotID++) {
+    for (slotID=0; ; slotID++) {
 #ifdef DEBUG
-        if(slotID >= MAX_N_REGISTER)
+        if (slotID >= MAX_N_REGISTER)
         {
             ebsp_message("ERROR: bsp_hpput(%d, %p, %p, %d, %d) could not find dst", pid, src, dst, offset, nbytes);
             return;
         }
 #endif
-        //Find the slot for our local _pid
-        if(coredata.registermap[coredata.nprocs*slotID + coredata.pid] == dst)
+        // Find the slot for our local _pid
+        if (coredata.registermap[coredata.nprocs * slotID + coredata.pid] == dst)
         {
-            //Then get the entry of remote pid
-            adj_dst = coredata.registermap[coredata.nprocs*slotID + pid];
+            // Then get the entry of remote pid
+            adj_dst = coredata.registermap[coredata.nprocs * slotID + pid];
             break;
         }
     }
@@ -165,7 +165,7 @@ void ebsp_message(const char* format, ... )
     //vsnprintf(&comm_buf->message[coredata.pid].msg[0], sizeof(ebsp_message_buf), format, args);
     va_end(args);
 
-    // DEBUG: vsnprintf does not seem to work
+    // TODO: vsnprintf does not seem to work
     // instead just memcpy the format string and add a terminating 0
     memcpy(&comm_buf->message[coredata.pid].msg[0], format, sizeof(ebsp_message_buf));
     comm_buf->message[coredata.pid].msg[127] = 0;

--- a/src/e_bsp.c
+++ b/src/e_bsp.c
@@ -154,24 +154,23 @@ void bsp_hpput(int pid, const void *src, void *dst, int offset, int nbytes)
 
 void ebsp_message(const char* format, ... )
 {
-    //TODO: Fix
-    return;
-
-    // First construct the message locally
-    ebsp_message_buf b;
-    va_list args;
-    va_start(args, format);
-    vsnprintf(&b.msg[0], sizeof(b.msg), format, args);
-    va_end(args);
-
     // Check if ARM core has written the previous message
     // so that we can overwrite the previous buffer
     while (coredata.msgflag != 0) {}
     coredata.msgflag = 1;
 
-    // First write the message
-    memcpy(&comm_buf->message[coredata.pid], &b, sizeof(ebsp_message_buf));
-    // Then write the flag indicating that the message is complete
+    // Write the message to comm_buf->message
+    va_list args;
+    va_start(args, format);
+    //vsnprintf(&comm_buf->message[coredata.pid].msg[0], sizeof(ebsp_message_buf), format, args);
+    va_end(args);
+
+    // DEBUG: vsnprintf does not seem to work
+    // instead just memcpy the format string and add a terminating 0
+    memcpy(&comm_buf->message[coredata.pid].msg[0], format, sizeof(ebsp_message_buf));
+    comm_buf->message[coredata.pid].msg[127] = 0;
+
+    // Write the flag indicating that the message is complete
     comm_buf->msgflag[coredata.pid] = 1;
 }
 

--- a/src/host_bsp.c
+++ b/src/host_bsp.c
@@ -275,12 +275,12 @@ int ebsp_spmd()
 
         if (sync_counter == state.nprocs) {
 #ifdef DEBUG
-            printf("(BSP) DEBUG: Syncing on host...\n");
+            printf("(BSP) DEBUG: Syncing\n");
 #endif
             _host_sync();
 
 #ifdef DEBUG
-            printf("(BSP) DEBUG: Writing STATE_CONTINUE to processors...\n");
+            printf("(BSP) DEBUG: Writing STATE_CONTINUE to processors\n");
 #endif
             state_flag = STATE_CONTINUE;
             for(i = 0; i < state.nprocs; i++) {
@@ -290,7 +290,7 @@ int ebsp_spmd()
                 co_write(i, &state_flag, (off_t)SYNC_STATE_ADDRESS, sizeof(int));
             }
 #ifdef DEBUG
-            printf("(BSP) DEBUG: Continuing...\n");
+            printf("(BSP) DEBUG: Syncing finished\n");
 #endif
         }
 
@@ -339,22 +339,19 @@ void _host_sync() {
 
     int i, j;
     int new_vars = 0;
-#ifdef DEBUG
-    printf("(BSP) DEBUG: _host_sync() ............................... \n");
-#endif
 
     void* var_loc = NULL;
     _read_sharedmem(0, SHM_OFFSET_REGISTER, &var_loc, sizeof(void*));
         
-#ifdef DEBUG
-    printf("var_loc = 0x%x\n", (int)var_loc);
-#endif
-
     if(var_loc != NULL) {
         new_vars = 1;
     } else {
         return;
     }
+
+#ifdef DEBUG
+    printf("(BSP) DEBUG: bsp_push_reg occurred. var_loc = 0x%x\n", (int)var_loc);
+#endif
 
     if (state.num_vars_registered >= MAX_N_REGISTER)
     {

--- a/src/host_bsp.c
+++ b/src/host_bsp.c
@@ -453,7 +453,7 @@ void _host_sync() {
             state.comm_buf.pushregloc[i] = 0;
 
         _write_extmem(&state.comm_buf.pushregloc,
-                offsetof(ebsp_comm_buf, pushreglog),
+                offsetof(ebsp_comm_buf, pushregloc),
                 _NPROCS * sizeof(void*));
     }
 }

--- a/src/host_bsp.c
+++ b/src/host_bsp.c
@@ -38,8 +38,6 @@ int bsp_initialized = 0;;
 void _host_sync();
 void _get_p_coords(int pid, int* row, int* col);
 bsp_state_t* _get_state();
-int  _read_sharedmem(int pid,       off_t src, void* dst, int size);
-int _write_sharedmem(int pid, const void* src, off_t dst, int size);
 
 int co_write(int pid, void* src, off_t dst, int size)
 {
@@ -69,6 +67,11 @@ int co_read(int pid, off_t src, void* dst, int size)
         return 0;
     }
     return 1;
+}
+
+int write_coredata(int pid, void* src, off_t offset, int size)
+{
+    return co_write(pid, src, state.comm_buf.coredata[pid] + offset, size);
 }
 
 int bsp_init(const char* _e_name,
@@ -160,115 +163,137 @@ int bsp_begin(int nprocs)
         return 0;
     }
 
-    // Write the nprocs to memory
-    int i, j;
-    for(i = 0; i < state.platform.rows; ++i) {
-        for(j = 0; j < state.platform.cols; ++j) {
-            if (e_write(&state.dev, i, j, (off_t)NPROCS_LOC_ADDRESS,
-                        &state.nprocs, sizeof(int)) != sizeof(int)) {
-                fprintf(stderr, "ERROR: e_write(dev,%d,%d,..) failed in bsp_begin.\n",i,j);
-                return 0;
-            }
-        }
-    }
-
-    // Allocate shared memory buffer
-    int shm_size = SHM_SIZE_PER_CORE * state.nprocs;
-    if (e_shm_alloc(&state.sharedmemseg, SHM_NAME, shm_size) != E_OK)
+    // Allocate communication buffer
+    if (e_alloc(&state.emem, COMMBUF_OFFSET, sizeof(ebsp_comm_buf)) != E_OK)
     {
-        fprintf(stderr, "ERROR: e_shm_alloc failed in bsp_begin.\n");
-        return 0; 
-    }
-
-    //Set shared memory buffer to zero
-    void* buf = malloc(shm_size);
-    memset(buf, 0, shm_size);
-    int res = e_write(&state.sharedmemseg, 0, 0, (off_t)0, buf, shm_size);
-    free(buf);
-    if (res != shm_size)
-    {
-        fprintf(stderr, "ERROR: writing shared memory failed in bsp_begin.\n");
+        fprintf(stderr, "ERROR: e_alloc failed in bspbegin.\n");
         return 0;
     }
+
+    // Set initial values of buffer: zeroes and nprocs
+    memset(&state.comm_buf, 0, sizeof(ebsp_comm_buf));
+    state.comm_buf.nprocs = state.nprocs;
+
+    // Write to epiphany
+    if (e_write(&state.emem, 0, 0, 0, &state.comm_buf,
+                sizeof(ebsp_comm_buf)) != sizeof(ebsp_comm_buf))
+    {
+        fprintf(stderr, "ERROR: e_write ebsp_comm_buf failed in bsp_begin.\n");
+        return 0;
+    }
+
     return 1;
 }
 
 int ebsp_spmd()
 {   
-    int i = 0;
-    int j = 0;
-
-    clock_t start=clock(); 
-    clock_t end=clock(); 
-    float arm_timer;
-    arm_timer = (float)(end-start)/ARM_CLOCKSPEED;
-    for(i = 0; i < state.nprocs; i++) {
-        co_write(i, &arm_timer, (off_t)REMOTE_TIMER_ADDRESS, sizeof(int));
-    }
-    
     // Start the program
+    // The program will block on bsp_begin
+    // in state STATE_INIT
+    // untill we send a STATE_CONTINUE
+    // Before that, we have to fill its buffers
+    // with data like timers
     if (e_start_group(&state.dev) != E_OK) {
         fprintf(stderr, "ERROR: e_start_group() failed.\n");
         return 0;
     }
-    // sleep for 0.01 seconds
-    usleep(1000);
 
-    int total_syncs = 0;
-    int state_flag = 0;
-    int message_flag = 0;
-    char message_buffer[SHM_MESSAGE_SIZE+1];
+    int i, j;
+    int cores_initialized = 0;
+    while (cores_initialized != state.nprocs)
+    {
+        usleep(1000); //0.01 seconds
 
+        // Read the full communication buffer
+        if (e_read(&state.emem, 0, 0, 0, &state.comm_buf,
+                    sizeof(ebsp_comm_buf)) != sizeof(ebsp_comm_buf))
+        {
+            fprintf(stderr, "ERROR: e_read ebsp_comm_buf failed in ebsp_spmd.\n");
+            return 0;
+        }
+
+        // Check every core
+        for(i = 0; i < state.nprocs; ++i)
+            if (state.comm_buf.syncstate[i] == STATE_INIT)
+                ++cores_initialized;
+    }
+
+    //All cores are waiting.
+    //We can now send data and 'start' them
+    clock_t start=clock(); 
+    clock_t end=clock(); 
+    float arm_timer;
+    arm_timer = (float)(end-start)/ARM_CLOCKSPEED;
+    for(i = 0; i < state.nprocs; ++i)
+    {
+        //Core i has written its coredata address
+        //Now we can initialize it
+        write_coredata(i, &arm_timer, offsetof(ebsp_coredata, remotetimer), sizeof(int));
+        //All data is initialized. Send start signal
+        int flag = STATE_CONTINUE;
+        write_coredata(i, &flag, offsetof(ebsp_coredata, syncstate), sizeof(int));
+    }
+
+    int total_syncs      = 0;
     int run_counter      = 0;
     int sync_counter     = 0;
     int finish_counter   = 0; 
     int continue_counter = 0;
 
     int iter = 0;
-    message_buffer[SHM_MESSAGE_SIZE] = 0; //terminating zero
 
     while (finish_counter != state.nprocs) {
+        //Write timer
         end=clock(); 
         arm_timer = (float)(end-start)/ARM_CLOCKSPEED;
-        for(i = 0; i < state.nprocs; i++) {
-            co_write(i, &arm_timer, (off_t)REMOTE_TIMER_ADDRESS, sizeof(int));
+        for(i = 0; i < state.nprocs; i++)
+            write_coredata(i, &arm_timer, offsetof(ebsp_coredata, remotetimer), sizeof(int));
+
+        // Read the full communication buffer
+        // Including pushreg states and so on
+        if (e_read(&state.emem, 0, 0, 0, &state.comm_buf,
+                    sizeof(ebsp_comm_buf)) != sizeof(ebsp_comm_buf))
+        {
+            fprintf(stderr, "ERROR: e_read ebsp_comm_buf failed in ebsp_spmd.\n");
+            return 0;
         }
+
+        //Check sync states
         run_counter      = 0;
         sync_counter     = 0;
         finish_counter   = 0;
         continue_counter = 0;
         for (i = 0; i < state.nprocs; i++) {
-            state_flag = 0;
-            //co_read(i, (off_t)SYNC_STATE_ADDRESS, &state_flag, sizeof(int));
-            _read_sharedmem(i, SHM_OFFSET_SYNC, &state_flag, sizeof(int));
-
-            if (state_flag == STATE_RUN     ) run_counter++;
-            else if (state_flag == STATE_SYNC    ) sync_counter++;
-            else if (state_flag == STATE_FINISH  ) finish_counter++;
-            else if (state_flag == STATE_CONTINUE) continue_counter++;
-
-            //First read a single int to see if there is a message
-            _read_sharedmem(i, SHM_OFFSET_MSG_FLAG, &message_flag, sizeof(int));
-            if (message_flag)
+            switch (state.comm_buf.syncstate[i]){
+                case STATE_RUN:      run_counter++; break;
+                case STATE_SYNC:     sync_counter++; break;
+                case STATE_FINISH:   finish_counter++; break;
+                case STATE_CONTINUE: continue_counter++; break;
+                default: fprintf(stderr, "ERROR: syncstate[%d] = %d.\n",
+                                 i, state.comm_buf.syncstate[i]);
+                         break;
+            }
+            if (state.comm_buf.msgflag[i])
             {
-                //Now read the full message
-                _read_sharedmem(i, SHM_OFFSET_MSG_BUF, &message_buffer, SHM_MESSAGE_SIZE);
-                printf("$%02d: %s\n", i, message_buffer);
+                printf("$%02d: %s\n", i, state.comm_buf.message[i].msg);
                 //Reset flag so we do not read it again
-                message_flag = 0;
-                _write_sharedmem(i, &message_flag, SHM_OFFSET_MSG_FLAG, sizeof(int));
+                state.comm_buf.msgflag[i] = 0;
+                //Write the int to the external comm_buf
+                e_write(&state.emem, 0, 0, offsetof(ebsp_comm_buf, msgflag[i]),
+                        &state.comm_buf.msgflag[i], sizeof(int));
                 //Signal epiphany core that message was read
                 //so that it can (possibly) output the next message
-                co_write(i, &message_flag, MSG_SYNC_ADDRESS, sizeof(int));
+                write_coredata(i, &state.comm_buf.msgflag[i],
+                        offsetof(ebsp_coredata, msgflag), sizeof(int));
             }
         }
 
 #ifdef DEBUG
         if (iter % 1000 == 0) {
             printf("Current time: %E seconds\n", arm_timer);
-            printf("run %02d - sync %02d - finish %02d - continue %02d - 16th stateflag %d\n",
+            printf("run %02d - sync %02d - finish %02d - continue %02d\n",
                     run_counter, sync_counter, finish_counter,
-                    continue_counter, state_flag);
+                    continue_counter);
         }
         ++iter;
 #endif
@@ -283,13 +308,15 @@ int ebsp_spmd()
 #endif
             _host_sync();
 
-            state_flag = STATE_CONTINUE;
-            for(i = 0; i < state.nprocs; i++) {
-                //shared mem, to reset flag
-                _write_sharedmem(i, &state_flag, SHM_OFFSET_SYNC, sizeof(int));
-                //to core, will cause execution to continue
-                co_write(i, &state_flag, (off_t)SYNC_STATE_ADDRESS, sizeof(int));
-            }
+            //First reset the comm_buf
+            for(i = 0; i < state.nprocs; i++)
+                state.comm_buf.syncstate[i] = STATE_CONTINUE;
+            e_write(&state.emem, 0, 0, offsetof(ebsp_comm_buf, syncstate),
+                    &state.comm_buf.syncstate, _NPROCS*sizeof(int));
+            //Now write it to all cores to continue their execution
+            for(i = 0; i < state.nprocs; i++)
+                write_coredata(i, &state.comm_buf.syncstate[i],
+                        offsetof(ebsp_coredata, syncstate), sizeof(int));
         }
 
         usleep(1000);
@@ -305,10 +332,8 @@ int bsp_end()
         fprintf(stderr, "ERROR: bsp_end called when bsp was not initialized.\n");
         return 0;
     }
-    
-    //Release shared memory
-    if (e_shm_release(SHM_NAME) != E_OK)
-        fprintf(stderr, "ERROR: e_shm_release failed in bsp_end.\n");
+
+    e_free(&state.emem);
 
     if(E_OK != e_finalize()) {
         fprintf(stderr, "ERROR: Could not finalize the Epiphany connection.\n");
@@ -334,53 +359,44 @@ int bsp_nprocs()
 // Memory
 void _host_sync() {
     // TODO: Right now bsp_pop_reg is ignored
-
     int i, j;
-    int new_vars = 0;
 
-    void* var_loc = NULL;
-    _read_sharedmem(0, SHM_OFFSET_REGISTER, &var_loc, sizeof(void*));
-        
-    if(var_loc != NULL) {
-        new_vars = 1;
-    } else {
-        return;
-    }
-
+    // Check if core 0 did a push_reg
+    if (state.comm_buf.pushregloc[0] != NULL)
+    {
 #ifdef DEBUG
-    printf("(BSP) DEBUG: bsp_push_reg occurred. var_loc = 0x%x\n", (int)var_loc);
+        printf("(BSP) DEBUG: bsp_push_reg occurred. addr = 0x%x\n",
+                state.comm_buf.pushregloc[0]);
 #endif
 
-    if (state.num_vars_registered >= MAX_N_REGISTER)
-    {
-        fprintf(stderr, "ERROR: Trying to register more than %d variables.\n",
-                MAX_N_REGISTER);
-    }
-    else
-    {
-        // Broadcast registermap_buffer to registermap 
-        void** buf = (void**) malloc(sizeof(void*) * state.nprocs);
-        for(i = 0; i < state.nprocs; ++i)
-            _read_sharedmem(i, SHM_OFFSET_REGISTER, buf+i, sizeof(void*));
-        for(i = 0; i < state.nprocs; ++i) {
-            co_write(i, buf,
-                    (off_t)(REGISTERMAP_ADDRESS + state.num_vars_registered * state.nprocs), 
-                    sizeof(void*) * state.nprocs);
+        if (state.num_vars_registered >= MAX_N_REGISTER)
+        {
+            fprintf(stderr, "ERROR: Trying to register more than %d variables.\n",
+                    MAX_N_REGISTER);
         }
-        free(buf);
+        else
+        {
+            // Broadcast registermap_buffer to registermap 
+            for(i = 0; i < state.nprocs; ++i) {
+                write_coredata(i, state.comm_buf.pushregloc,
+                        (off_t)(offsetof(ebsp_coredata, registermap) +
+                            sizeof(void*) * state.num_vars_registered * state.nprocs),
+                        sizeof(void*) * state.nprocs);
+            }
 
-        state.num_vars_registered++;
+            state.num_vars_registered++;
 #ifdef DEBUG
-        printf("(BSP) DEBUG: New variables registered: %i/%i\n",
-                state.num_vars_registered,MAX_N_REGISTER);
+            printf("(BSP) DEBUG: New variables registered: %i/%i\n",
+                    state.num_vars_registered,MAX_N_REGISTER);
 #endif
-    }
+        }
 
-    // Reset registermap_buffer to zero
-    void* buffer = 0;
-    //FIXME; ee_mwrite_buf(): Address is out of bounds.
-    for(i = 0; i < state.nprocs; ++i)
-        _write_sharedmem(i, &buffer, SHM_OFFSET_REGISTER, sizeof(void*));
+        // Reset pushregloc to zero
+        for(i = 0; i < state.nprocs; ++i)
+            state.comm_buf.pushregloc[i] = 0;
+        e_write(&state.emem, &state.comm_buf.pushregloc,
+                offsetof(ebsp_comm_buf, pushregloc), _NPROCS*sizeof(void*));
+    }
 }
 
 void _get_p_coords(int pid, int* row, int* col)
@@ -393,31 +409,4 @@ bsp_state_t* _get_state()
 {
     return &state;
 }
-
-//Read from shared memory
-int  _read_sharedmem(int pid, off_t src, void* dst, int size)
-{
-    off_t realsrc = pid * SHM_SIZE_PER_CORE + src;
-    if (e_read(&state.sharedmemseg, 0, 0, realsrc, dst, size) != size)
-    {
-        fprintf(stderr, "ERROR: read_sharedmem(%d, %d, dst, %d) failed.\n",
-                pid, (int)src, size);
-        return 0;
-    }
-    return 1;
-}
-
-//Write to shared memory
-int _write_sharedmem(int pid, const void* src, off_t dst, int size)
-{
-    off_t realdst = pid * SHM_SIZE_PER_CORE + dst;
-    if (e_write(&state.sharedmemseg, 0, 0, realdst, src, size) != size)
-    {
-        fprintf(stderr, "ERROR: write_sharedmem(%d, src, %d, %d) failed.\n",
-                pid, (int)dst, size);
-        return 0;
-    }
-    return 1;
-}
-
 


### PR DESCRIPTION
- Shared memory fully replaced by external memory
- All hardcoded addresses removed.
- All bsp variables are stored in a struct
