### PR TITLE
Correction of remaining bytes in memcopy aligned cases

### DIFF
--- a/src/e_bsp_memory.c
+++ b/src/e_bsp_memory.c
@@ -91,7 +91,7 @@ void ebsp_memcpy(void* dest, const void* source, size_t nbytes) {
         while (count--)
             *dst++ = *src++;
         dest = (void*)dst;
-        source = (void*)source;
+        source = (void*)src;
     } else if ((bits & 0x3) == 0) {
         // 4-byte aligned
         uint32_t* dst = (uint32_t*)dest;
@@ -101,7 +101,7 @@ void ebsp_memcpy(void* dest, const void* source, size_t nbytes) {
         while (count--)
             *dst++ = *src++;
         dest = (void*)dst;
-        source = (void*)source;
+        source = (void*)src;
     }
 
     // do remaining bytes 1-byte aligned


### PR DESCRIPTION
There is a typo-like error in the aligned cases of `ebsp_memcpy`. The remaining bytes will not be copied correctly, as the source pointer is not changed. I attached a standalone test case that shows the output of each version.

[copytest.txt](https://github.com/coduin/epiphany-bsp/files/195759/copytest.txt)
